### PR TITLE
Add OpenAI client error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # liteaifrm
 Lite framework for Responses Api
+
+## Configuration
+
+The utilities expect an OpenAI API key to be available. Set the
+`OPENAI_API_KEY` environment variable or specify `openai_api_key` in your
+configuration file before running the agents.
+

--- a/utils/openai_client.py
+++ b/utils/openai_client.py
@@ -1,7 +1,47 @@
 import openai
-from utils.secdata  import get_openai_api_key
+from utils.secdata import get_openai_api_key
+
 
 def get_client(config=None):
+    """Return an initialized OpenAI client.
+
+    Parameters
+    ----------
+    config : dict, optional
+        Optional config that may contain ``openai_api_key`` and ``base_url``
+        entries.
+
+    Returns
+    -------
+    object
+        Instance of :class:`openai.OpenAI` if available, otherwise the
+        configured ``openai`` module.
+
+    Raises
+    ------
+    RuntimeError
+        If no API key could be resolved.
+    """
     api_key = get_openai_api_key(config)
+    if not api_key:
+        raise RuntimeError(
+            "OpenAI API key not found. Set OPENAI_API_KEY env variable or provide it via config"
+        )
+
+    base_url = None
+    if config:
+        base_url = config.get("base_url") or config.get("openai_base_url")
+
+    if hasattr(openai, "OpenAI"):
+        if base_url:
+            return openai.OpenAI(api_key=api_key, base_url=base_url)
+        return openai.OpenAI(api_key=api_key)
+
+    # Fallback for older openai versions
     openai.api_key = api_key
+    if base_url:
+        if hasattr(openai, "base_url"):
+            openai.base_url = base_url
+        else:
+            openai.api_base = base_url
     return openai


### PR DESCRIPTION
## Summary
- raise an error when the API key is missing
- support configurable base URL for the OpenAI client
- document how to set `OPENAI_API_KEY`

## Testing
- `python -m py_compile utils/openai_client.py`

------
https://chatgpt.com/codex/tasks/task_e_686e424131d48328aa80ea5ea163807d