### PR TITLE
Add prompt path defaults for agents

### DIFF
--- a/agents/single.py
+++ b/agents/single.py
@@ -12,13 +12,14 @@ def run(input_data, config):
     temperature = single_settings.get("temperature") or config.get("temperature", 0.3)
 
     # Инструкции — из файла или из конфига:
-    prompt_path = single_settings.get("prompt_path")
+    prompt_path = single_settings.get("prompt_path") or config.get("prompt_path")
     if prompt_path:
         with open(prompt_path, "r", encoding="utf-8") as f:
             instructions = f.read()
     else:
-        instructions = single_settings.get("instructions") or config.get("instructions",
-                                                                         "Отвечай на вопрос пользователя используя предоставленный контекст.")
+        instructions = single_settings.get("instructions") or config.get(
+            "instructions",
+            "Отвечай на вопрос пользователя используя предоставленный контекст.")
 
     tools = single_settings.get("tools") or config.get("tools", [])
 
@@ -94,5 +95,4 @@ def run(input_data, config):
         "history": local_history + [
             {"role": "assistant", "content": [{"type": "output_text", "text": getattr(response, "output_text", "")}]}
         ]
-    }
-    return output
+    }    return output

--- a/config/agent_profile.yml
+++ b/config/agent_profile.yml
@@ -26,14 +26,18 @@ agent_sequence:
 
 agent_settings:
   summarizer:
+    prompt_path: "prompts/summarizer.txt"
     temperature: 0.4
     some_param: "value"
   researcher:
+    prompt_path: "prompts/researcher.txt"
     temperature: 0.15
     search_top_k: 5
   coder:
+    prompt_path: "prompts/coder.txt"
     max_tokens: 300
   runner:
+    prompt_path: "prompts/runner.txt"
     exec_timeout: 10
 
 # Для одиночного режима
@@ -41,5 +45,4 @@ single: single    # имя агента (например single.py, researcher.
 single_settings:
   prompt_path: "prompts/single_prompt.txt"
   temperature: 0.2
-  input: "Текст или вопрос для одиночного агента"
-  some_param: "одиночный режим"
+  input: "Текст или вопрос для одиночного агента"  some_param: "одиночный режим"

--- a/orchestration/sequential.py
+++ b/orchestration/sequential.py
@@ -4,9 +4,10 @@ def run_sequence(config):
     agent_sequence = config.get("agent_sequence", [])
     input_data = config.get("input", None)
     result = input_data
-    for agent_name in agent_sequence:
-        agent_mod = importlib.import_module(f"agents.{agent_name}")  # ← сначала импорт
+    for agent_name in agent_sequence:        agent_mod = importlib.import_module(f"agents.{agent_name}")  # ← сначала импорт
         agent_config = dict(config)
         agent_config.update(config.get("agent_settings", {}).get(agent_name, {}))
+        if "prompt_path" not in agent_config:
+            agent_config["prompt_path"] = f"prompts/{agent_name}.txt"
         result = agent_mod.run(result, agent_config)  # ← потом вызов
     return result

--- a/prompts/coder.txt
+++ b/prompts/coder.txt
@@ -1,0 +1,1 @@
+You are a coding agent. Write, improve and explain code snippets based on the task description.

--- a/prompts/researcher.txt
+++ b/prompts/researcher.txt
@@ -1,0 +1,1 @@
+You analyze code and research solutions. Execute code when necessary and report concise results.

--- a/prompts/runner.txt
+++ b/prompts/runner.txt
@@ -1,0 +1,1 @@
+You run provided code safely and return any output or errors from execution.

--- a/prompts/summarizer.txt
+++ b/prompts/summarizer.txt
@@ -1,0 +1,1 @@
+You are an expert summarizer. Provide a short, clear summary of any given text.


### PR DESCRIPTION
## Summary
- default each agent's prompt to `prompts/<name>.txt`
- create simple prompts for coder, researcher, runner and summarizer
- support `prompt_path` in sequential orchestration logic
- allow single agent to read `prompt_path` from general config

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686e4c35497883289a65e613b6674001