### PR TITLE
Add output text check in chat_gradio

### DIFF
--- a/gradio_app.py
+++ b/gradio_app.py
@@ -22,6 +22,8 @@ def chat_gradio(message, history):
             return result["research"]
         if "code" in result:
             return result["code"]
+        if "output_text" in result:
+            return result["output_text"]
         # иначе — просто показываем всё содержимое как текст
         return str(result)
     return str(result)


### PR DESCRIPTION
## Summary
- return `result["output_text"]` if present in the Gradio interface

## Testing
- `python gradio_app.py` *(fails: launching server but interactive input blocked)*
- `python main.py` *(fails: OpenAI API key missing)*

------
https://chatgpt.com/codex/tasks/task_e_686e63767e5c8328b26ec239d5d43d96