### PR TITLE
Fix duplicate return in single agent

### DIFF
--- a/agents/single.py
+++ b/agents/single.py
@@ -68,4 +68,3 @@ def run(input_data, config):
         ]
     }
     return output
-    return output


### PR DESCRIPTION
## Summary
- remove the extra `return output` at the end of `agents/single.py`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686e63a56ce083288fd81982e5fdf920