### PR TITLE
Implement additional orchestrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,19 @@ agent_settings:
 When `retriever.enabled` is true for an agent, the FAISS index will be loaded
 and used to provide additional context during generation.
 
+
+### Orchestration modes
+
+Set `orchestra_mode` to `true` in `config/agent_profile.yml` and choose one of
+five orchestration types via `orchestration_type`:
+`sequential`, `planner`, `tree`, `router` or `reflective`.
+The selected mode determines how agents are executed.
+
+* **sequential** – run agents from `agent_sequence` one after another.
+* **planner** – a `planner_agent` returns the list of agents to run.
+* **tree** – spawn agents according to `agent_tree` starting from its `root` key.
+* **router** – choose agents based on the `router_map` section and fields of the input.
+* **reflective** – after each agent a `reflection_agent` may request a retry.
+
+Switching the value in the YAML file allows quick experimentation with different
+execution strategies.

--- a/agents/reviewer.py
+++ b/agents/reviewer.py
@@ -1,0 +1,16 @@
+"""Simple reflection agent.
+
+This agent inspects the result of the previous step and can request a retry
+when it detects an error. It expects the input to be a dictionary created by
+other agents.
+"""
+
+def run(input_data, config):
+    # If previous step produced an error in ``code_result``, ask for a retry.
+    code_res = None
+    if isinstance(input_data, dict):
+        code_res = input_data.get("code_result")
+    if code_res and code_res.get("stderr"):
+        # Request to redo the last agent without modifications
+        return {"redo": True}
+    return {}

--- a/config/agent_profile.yml
+++ b/config/agent_profile.yml
@@ -57,3 +57,12 @@ single_settings:
   retriever:
     enabled: true
   some_param: "одиночный режим"
+
+# Additional orchestration settings
+# router_map: defines which agents handle a task key
+# router_map:
+#   summarize: summarizer
+#   code: [researcher, coder]
+# default_route: [summarizer]
+# reflection_agent: reviewer
+reflection_agent: reviewer

--- a/orchestration/controller.py
+++ b/orchestration/controller.py
@@ -1,5 +1,6 @@
 import importlib
 
+
 def run(config):
     if config.get("orchestra_mode"):
         typ = config.get("orchestration_type", "sequential")
@@ -12,10 +13,16 @@ def run(config):
         elif typ == "tree":
             from .tree import run_tree
             return run_tree(config)
+        elif typ == "router":
+            from .router import run_router
+            return run_router(config)
+        elif typ == "reflective":
+            from .reflective import run_reflective
+            return run_reflective(config)
         else:
             raise ValueError(f"Unknown orchestration_type: {typ}")
     else:
-        # Одиночный агент
+        # Single agent mode
         agent_name = config.get("single", config["agent_sequence"][0])
         agent_mod = importlib.import_module(f"agents.{agent_name}")
         input_data = config.get("input", None)

--- a/orchestration/reflective.py
+++ b/orchestration/reflective.py
@@ -1,0 +1,35 @@
+import importlib
+
+
+def run_reflective(config):
+    """Run agents sequentially with a reflection step after each agent.
+
+    The reflection agent can request a single retry by returning a dictionary
+    with ``redo`` set to True and an optional ``input`` field to replace the
+    previous result.
+    """
+    agent_sequence = config.get("agent_sequence", [])
+    reflection_agent = config.get("reflection_agent", "reviewer")
+    input_data = config.get("input", None)
+
+    result = input_data
+    reflection_mod = importlib.import_module(f"agents.{reflection_agent}")
+    reflection_cfg = dict(config)
+    reflection_cfg.update(config.get("agent_settings", {}).get(reflection_agent, {}))
+    if "prompt_path" not in reflection_cfg:
+        reflection_cfg["prompt_path"] = f"prompts/{reflection_agent}.txt"
+
+    for agent_name in agent_sequence:
+        agent_mod = importlib.import_module(f"agents.{agent_name}")
+        agent_config = dict(config)
+        agent_config.update(config.get("agent_settings", {}).get(agent_name, {}))
+        if "prompt_path" not in agent_config:
+            agent_config["prompt_path"] = f"prompts/{agent_name}.txt"
+        result = agent_mod.run(result, agent_config)
+
+        # Reflection step
+        feedback = reflection_mod.run(result, reflection_cfg)
+        if isinstance(feedback, dict) and feedback.get("redo"):
+            new_input = feedback.get("input", result)
+            result = agent_mod.run(new_input, agent_config)
+    return result

--- a/orchestration/router.py
+++ b/orchestration/router.py
@@ -1,0 +1,31 @@
+import importlib
+
+
+def run_router(config):
+    """Route input to one or more agents based on ``router_map``.
+
+    ``router_map`` is a mapping from route keys to agent names or lists of
+    agents. The key is resolved from ``input_data['task']`` or
+    ``input_data['route']``.
+    """
+    router_map = config.get("router_map", {})
+    default_route = config.get("default_route", [])
+    input_data = config.get("input", None)
+    if isinstance(input_data, dict):
+        route_key = input_data.get("task") or input_data.get("route")
+    else:
+        route_key = None
+
+    agent_names = router_map.get(route_key, default_route)
+    if isinstance(agent_names, str):
+        agent_names = [agent_names]
+
+    result = input_data
+    for agent_name in agent_names:
+        agent_mod = importlib.import_module(f"agents.{agent_name}")
+        agent_config = dict(config)
+        agent_config.update(config.get("agent_settings", {}).get(agent_name, {}))
+        if "prompt_path" not in agent_config:
+            agent_config["prompt_path"] = f"prompts/{agent_name}.txt"
+        result = agent_mod.run(result, agent_config)
+    return result

--- a/orchestration/sequential.py
+++ b/orchestration/sequential.py
@@ -1,10 +1,13 @@
 import importlib
 
+
 def run_sequence(config):
     agent_sequence = config.get("agent_sequence", [])
     input_data = config.get("input", None)
     result = input_data
-    for agent_name in agent_sequence:        agent_mod = importlib.import_module(f"agents.{agent_name}")  # ← сначала импорт
+    for agent_name in agent_sequence:
+        agent_mod = importlib.import_module(f"agents.{agent_name}")
+        result = agent_mod.run(result, agent_config)
         agent_config = dict(config)
         agent_config.update(config.get("agent_settings", {}).get(agent_name, {}))
         if "prompt_path" not in agent_config:


### PR DESCRIPTION
## Summary
- fix sequential orchestration module
- add router and reflective orchestrations with YAML switching
- provide simple reviewer agent for reflective mode
- document orchestration modes in README
- update controller and example config

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python main.py` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686e6ab8eea88328a8ca4374df7ce8bb